### PR TITLE
Fix .cjs issues, fix typescript warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,18 +26,25 @@
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require":  "./dist/index.cjs"
+    },
     "./mercCoords": {
       "types": "./dist/mercCoords.d.ts",
-      "import": "./dist/mercCoords.js"
+      "import": "./dist/mercCoords.js",
+      "require":  "./dist/mercCoords.cjs"
     },
     "./mercProjSpec": {
       "types": "./dist/mercProjSpec.d.ts",
-      "import": "./dist/mercProjSpec.js"
+      "import": "./dist/mercProjSpec.js",
+      "require":  "./dist/mercProjSpec.cjs"
     },
     "./util": {
       "types": "./dist/util.d.ts",
-      "import": "./dist/util.js"
+      "import": "./dist/util.js",
+      "require":  "./dist/util.cjs"
     }
   },
   "typesVersions": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,7 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
     /* Modules */
-    "module": "esnext",                                /* Specify what module code is generated. */
+    "module": "NodeNext",                                /* Specify what module code is generated. */
     "rootDir": "src",                                    /* Specify the root folder within your source files. */
     "moduleResolution": "NodeNext",                      /* Specify how TypeScript looks up a file from a given module specifier. */
     "baseUrl": ".",                                      /* Specify the base directory to resolve non-relative module names. */


### PR DESCRIPTION
Hello,

I found an issue when using a `.cjs` entrypoint to `require` this library. I added the required `exports` statement to fix the issue.

I also fixed a TypeScript warning that I got while building the library.